### PR TITLE
Added Usage Logging to Result Logger

### DIFF
--- a/maseval/core/callbacks/result_logger.py
+++ b/maseval/core/callbacks/result_logger.py
@@ -320,7 +320,7 @@ class FileResultLogger(ResultLogger):
         include_traces: bool = True,
         include_config: bool = True,
         include_eval: bool = True,
-        include_task: bool = False,
+        include_task: bool = True,
         include_usage: bool = True,
         validate_on_completion: bool = True,
     ):

--- a/tests/test_core/test_callbacks/test_result_logger.py
+++ b/tests/test_core/test_callbacks/test_result_logger.py
@@ -197,9 +197,24 @@ class TestResultLogger:
         assert filtered["task"]["query"] == "What is 2+2?"
         assert filtered["task"]["metadata"] == {"difficulty": "easy"}
 
-    def test_filter_report_excludes_task_by_default(self):
-        """Test that task data is excluded from filtered report by default."""
+    def test_filter_report_includes_task_by_default(self):
+        """Test that task data is included in filtered report by default."""
         logger = MockResultLogger()
+
+        report = {
+            "task_id": "task_0",
+            "repeat_idx": 0,
+            "task": {"query": "What is 2+2?", "metadata": {}, "protocol": {}},
+        }
+
+        filtered = logger._filter_report(report)
+
+        assert "task" in filtered
+        assert filtered["task"]["query"] == "What is 2+2?"
+
+    def test_filter_report_excludes_task_when_disabled(self):
+        """Test that task data is excluded from filtered report when include_task is False."""
+        logger = MockResultLogger(include_task=False)
 
         report = {
             "task_id": "task_0",


### PR DESCRIPTION
## Description

Fixed results logger to include usage.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, formatting, etc.)

## Checklist

### Contribution

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [ ] Added/updated docstrings for new/modified functions as instructed [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Updated relevant documentation in `docs/` (if applicable)
- [ ] Tag github issue with this PR (if applicable)

### Changelog

- [ ] Added entry to `CHANGELOG.md` under `[Unreleased]` section
  - Use **Added** section for new features
  - Use **Changed** section for modifications to existing functionality
  - Use **Fixed** section for bug fixes
  - Use **Removed** section for deprecated/removed features
- [ ] OR this is a documentation-only change (no changelog needed)

Example:
`- Support for multi-agent tracing (PR:#123)`

### Architecture (if applicable)

- [ ] Core/Interface separation: Changes in `maseval/core/` do NOT import from `maseval/interface/`
- [ ] Dependencies: New core dependencies added sparingly; framework integrations go to optional dependencies

## Additional Notes

<!-- Any additional context, screenshots, or information reviewers should know -->
