### PR TITLE
Fix simulator logs containing future messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Core**
+
+- Fixed `MessageHistory.to_list()` returning a reference to the internal list instead of a copy, causing simulator logs to contain future conversation messages that hadn't occurred at the time of logging. (PR: #PR_NUMBER_PLACEHOLDER)
+
 ### Added
 
 **Core**

--- a/maseval/core/history.py
+++ b/maseval/core/history.py
@@ -110,7 +110,7 @@ class MessageHistory:
         Returns:
             List of message dictionaries in OpenAI format
         """
-        return self._messages
+        return list(self._messages)
 
     def add_message(
         self,


### PR DESCRIPTION
## Description

`MessageHistory.to_list()` returned a direct reference to the internal `_messages` list. This caused simulator log entries to be mutated after creation. Each entry's `conversation_history` ended up containing messages from future turns that hadn't occurred at logging time. Fixed by returning a shallow copy.

Fixes #5

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, formatting, etc.)

## Checklist

### Contribution

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] Added/updated docstrings for new/modified functions as instructed [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Updated relevant documentation in `docs/` (if applicable)
- [x] Tag github issue with this PR (if applicable)

### Changelog

- [x] Added entry to `CHANGELOG.md` under `[Unreleased]` section
  - Use **Added** section for new features
  - Use **Changed** section for modifications to existing functionality
  - Use **Fixed** section for bug fixes
  - Use **Removed** section for deprecated/removed features
- [ ] OR this is a documentation-only change (no changelog needed)

### Architecture (if applicable)

- [x] Core/Interface separation: Changes in `maseval/core/` do NOT import from `maseval/interface/`
- [x] Dependencies: New core dependencies added sparingly; framework integrations go to optional dependencies

## Additional Notes

None.