### PR TITLE
Fix: silent exception swallowing loses config in agent adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `MessageHistory.to_list()` returning a reference to the internal list instead of a copy, causing simulator logs to contain future conversation messages that hadn't occurred at the time of logging. (PR: #PR_NUMBER_PLACEHOLDER)
 
+**Interface**
+
+- Agent adapter `gather_config()` in smolagents, langgraph, and llamaindex no longer silently swallows exceptions, ensuring config collection errors are visible instead of producing incomplete configuration data. (PR: #53)
+
 ### Added
 
 **Core**

--- a/maseval/interface/agents/langgraph.py
+++ b/maseval/interface/agents/langgraph.py
@@ -218,17 +218,15 @@ class LangGraphAgentAdapter(AgentAdapter):
                     safe_config["configurable"] = {"has_thread_id": "thread_id" in value if isinstance(value, dict) else False}
             langgraph_config["config"] = safe_config
 
-        # Try to get graph structure info
+        # Get graph structure info — let errors propagate so they're
+        # visible in the registry's error output.
         if hasattr(self.agent, "get_graph"):
-            try:
-                graph = self.agent.get_graph()
-                if graph:
-                    langgraph_config["graph_info"] = {
-                        "num_nodes": len(graph.nodes) if hasattr(graph, "nodes") else None,
-                        "num_edges": len(graph.edges) if hasattr(graph, "edges") else None,
-                    }
-            except Exception:
-                pass
+            graph = self.agent.get_graph()
+            if graph:
+                langgraph_config["graph_info"] = {
+                    "num_nodes": len(graph.nodes) if hasattr(graph, "nodes") else None,
+                    "num_edges": len(graph.edges) if hasattr(graph, "edges") else None,
+                }
 
         if langgraph_config:
             base_config["langgraph_config"] = langgraph_config

--- a/maseval/interface/agents/llamaindex.py
+++ b/maseval/interface/agents/llamaindex.py
@@ -211,14 +211,12 @@ class LlamaIndexAgentAdapter(AgentAdapter):
                     for tool in tools
                 ]
 
-        # Check if it's a workflow
+        # Check if it's a workflow — let errors propagate so they're
+        # visible in the registry's error output.
         if hasattr(self.agent, "get_config"):
-            try:
-                workflow_config = self.agent.get_config()
-                if workflow_config:
-                    llamaindex_config["workflow_config"] = workflow_config
-            except Exception:
-                pass
+            workflow_config = self.agent.get_config()
+            if workflow_config:
+                llamaindex_config["workflow_config"] = workflow_config
 
         if llamaindex_config:
             base_config["llamaindex_config"] = llamaindex_config

--- a/maseval/interface/agents/smolagents.py
+++ b/maseval/interface/agents/smolagents.py
@@ -425,32 +425,11 @@ class SmolAgentAdapter(AgentAdapter):
         base_config = super().gather_config()
         _check_smolagents_installed()
 
-        # Get comprehensive config from smolagents' native to_dict() method
-        smolagents_config = {}
+        # Get comprehensive config from smolagents' native to_dict() method.
+        # No try/except: if to_dict() exists but fails, the error should
+        # propagate so it's visible in the registry's error output.
         if hasattr(self.agent, "to_dict"):
-            try:
-                smolagents_config = self.agent.to_dict()
-            except Exception:
-                # If to_dict fails, fall back to basic attributes
-                pass
-
-        # Add smolagents-specific config if available
-        if smolagents_config:
-            base_config["smolagents_config"] = smolagents_config
-        else:
-            # Fallback: manually collect common attributes
-            config_attrs = {}
-            for attr in ["max_steps", "planning_interval", "name", "description"]:
-                if hasattr(self.agent, attr):
-                    config_attrs[attr] = getattr(self.agent, attr)
-
-            # CodeAgent-specific attributes
-            for attr in ["additional_authorized_imports", "authorized_imports", "executor_type"]:
-                if hasattr(self.agent, attr):
-                    config_attrs[attr] = getattr(self.agent, attr)
-
-            if config_attrs:
-                base_config["smolagents_config"] = config_attrs
+            base_config["smolagents_config"] = self.agent.to_dict()
 
         return base_config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,6 +217,9 @@ class FakeSmolagentsModel:
         self._responses = responses or ["mock response"]
         self._call_index = 0
 
+    def to_dict(self) -> dict:
+        return {"class": self.__class__.__name__, "model_id": self.model_id}
+
     def __call__(self, *args, **kwargs):
         return self.generate(*args, **kwargs)
 


### PR DESCRIPTION
## Description

The `except Exception: pass` blocks in `gather_config()` across smolagents, langgraph, and llamaindex adapters silently swallowed errors during config collection, causing loss of configuration data (including model_id) with no visibility into why.

This PR removes those silent catch-all blocks and lets errors propagate. For research code, truthfulness matters more than uptime — failures should be visible so they can be diagnosed and fixed.

Also simplified `SmolAgentAdapter.gather_config()` by removing the manual fallback that partially reconstructed config when `to_dict()` failed, since the error now surfaces directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Contribution

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] Added/updated docstrings for new/modified functions as instructed [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Updated relevant documentation in `docs/` (if applicable)
- [ ] Tag github issue with this PR (if applicable)

### Changelog

- [x] Added entry to `CHANGELOG.md` under `[Unreleased]` section
- [ ] OR this is a documentation-only change (no changelog needed)

### Architecture (if applicable)

- [x] Core/Interface separation: Changes in `maseval/core/` do NOT import from `maseval/interface/`
- [x] Dependencies: New core dependencies added sparingly; framework integrations go to optional dependencies

## Additional Notes

All three agent adapters (smolagents, langgraph, llamaindex) had the same pattern of `except Exception: pass` in their config collection. This PR applies the same fix consistently across all three.