### PR TITLE
Fixing inconsistent error traces across failure modes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed MACS real-data tests passing `{"environment_data": task.environment_data}` instead of `task.environment_data` directly, which caused `setup_state` to silently receive an empty tools list. (PR: #58)
+- Benchmark reports from `Benchmark.run()` now have a consistent schema across every outcome. Setup failures, setup timeouts, and unexpected worker failures in parallel runs previously produced reports missing the `usage` and `task` keys (with empty `traces`/`config`). Every report now always includes `task_id`, `repeat_idx`, `status`, `error`, `traces`, `config`, `usage`, `eval`, and `task`, and `report["error"]` is always populated whenever `status` is not `SUCCESS`. (PR: #61)
+- `fail_on_setup_error`, `fail_on_task_error`, and `fail_on_evaluation_error` now abort a parallel `Benchmark.run()` the same way they abort a sequential run. Previously a parallel run swallowed the failure into a degraded report and kept going. (PR: #61)
 
 ### Removed
 

--- a/maseval/core/benchmark.py
+++ b/maseval/core/benchmark.py
@@ -519,6 +519,64 @@ class Benchmark(ABC):
 
         return errors
 
+    def _build_report(
+        self,
+        task: Task,
+        repeat_idx: int,
+        status: TaskExecutionStatus,
+        *,
+        error: Optional[Dict[str, Any]] = None,
+        traces: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]] = None,
+        usage: Optional[Dict[str, Any]] = None,
+        eval_results: Any = None,
+    ) -> Dict[str, Any]:
+        """Build a task-repetition report with the canonical schema.
+
+        Every report — success or failure, from setup, execution or evaluation,
+        and from sequential or parallel runs — carries the same top-level keys so
+        downstream consumers can rely on a stable schema. ``error`` is ``None``
+        only for ``SUCCESS``; for any other status it is always populated (a
+        generic placeholder is synthesised if a caller forgot to supply one).
+
+        Args:
+            task: The task this report describes.
+            repeat_idx: Repetition index (0 to n_task_repeats-1).
+            status: Final execution status for this repetition.
+            error: Error details dict (``error_type``/``error_message``/``traceback``,
+                plus any extra fields), or ``None`` if the repetition succeeded.
+            traces: Collected execution traces (defaults to ``{}`` when not available).
+            config: Collected component/benchmark configuration (defaults to ``{}``).
+            usage: Collected usage totals, or ``None`` if not collected.
+            eval_results: Evaluation results, or ``None`` if evaluation was skipped or failed.
+
+        Returns:
+            Report dictionary with keys: ``task_id``, ``repeat_idx``, ``status``,
+            ``error``, ``traces``, ``config``, ``usage``, ``eval``, ``task``.
+        """
+        if status is not TaskExecutionStatus.SUCCESS and error is None:
+            # Defensive: a non-success report must always carry error details.
+            error = {
+                "error_type": "UnknownError",
+                "error_message": f"Task ended with status '{status.value}' but no error details were recorded.",
+                "traceback": "",
+            }
+        return {
+            "task_id": str(task.id),
+            "repeat_idx": repeat_idx,
+            "status": status.value,
+            "error": error,
+            "traces": traces if traces is not None else {},
+            "config": config if config is not None else {},
+            "usage": usage,
+            "eval": eval_results,
+            "task": {
+                "query": task.query,
+                "metadata": dict(task.metadata),
+                "protocol": task.protocol.to_dict(),
+            },
+        }
+
     def _append_report_safe(self, report: Dict[str, Any]) -> None:
         """Append a report to the reports list (thread-safe).
 
@@ -1089,16 +1147,14 @@ class Benchmark(ABC):
                 "traceback": "".join(traceback.format_exception(type(e), e, e.__traceback__)),
             }
 
-            # Create a minimal report for this timeout
-            report = {
-                "task_id": str(task.id),
-                "repeat_idx": repeat_idx,
-                "status": execution_status.value,
-                "error": error_info,
-                "traces": e.partial_traces,
-                "config": {},
-                "eval": None,
-            }
+            # Create a minimal report for this timeout (canonical schema)
+            report = self._build_report(
+                task,
+                repeat_idx,
+                execution_status,
+                error=error_info,
+                traces=e.partial_traces,
+            )
             self.clear_registry()
             return report
 
@@ -1111,22 +1167,13 @@ class Benchmark(ABC):
                 "traceback": "".join(traceback.format_exception(type(e), e, e.__traceback__)),
             }
 
-            # Create a minimal report for this failed setup
-            report = {
-                "task_id": str(task.id),
-                "repeat_idx": repeat_idx,
-                "status": execution_status.value,
-                "error": error_info,
-                "traces": {},
-                "config": {},
-                "eval": None,
-            }
             self.clear_registry()
 
             if self.fail_on_setup_error:
                 raise
 
-            return report
+            # Create a minimal report for this failed setup (canonical schema)
+            return self._build_report(task, repeat_idx, execution_status, error=error_info)
 
         # 2. Execute agent system with optional user interaction loop
         try:
@@ -1265,21 +1312,16 @@ class Benchmark(ABC):
             eval_results = None
 
         # 5. Build report — all keys always present for consistent schema
-        report: Dict[str, Any] = {
-            "task_id": str(task.id),
-            "repeat_idx": repeat_idx,
-            "status": execution_status.value,
-            "error": error_info,
-            "traces": execution_traces,
-            "config": execution_configs,
-            "usage": execution_usage,
-            "eval": eval_results,
-            "task": {
-                "query": task.query,
-                "metadata": dict(task.metadata),
-                "protocol": task.protocol.to_dict(),
-            },
-        }
+        report = self._build_report(
+            task,
+            repeat_idx,
+            execution_status,
+            error=error_info,
+            traces=execution_traces,
+            config=execution_configs,
+            usage=execution_usage,
+            eval_results=eval_results,
+        )
 
         # Clear registry after task repetition completes
         self.clear_registry()
@@ -1391,20 +1433,26 @@ class Benchmark(ABC):
                     try:
                         report = future.result()
                     except Exception as e:
-                        # Create error report for unexpected failures
-                        report = {
-                            "task_id": task_id,
-                            "repeat_idx": repeat_idx,
-                            "status": TaskExecutionStatus.UNKNOWN_EXECUTION_ERROR.value,
-                            "error": {
+                        # A deliberate fail-fast re-raise from _execute_task_repetition
+                        # (fail_on_setup_error / fail_on_task_error / fail_on_evaluation_error)
+                        # must abort the parallel run, matching sequential semantics — rather
+                        # than being swallowed into a degraded report and letting the run continue.
+                        if self.fail_on_setup_error or self.fail_on_task_error or self.fail_on_evaluation_error:
+                            executor.shutdown(wait=False, cancel_futures=True)
+                            raise
+                        # Otherwise this is an unexpected failure inside the worker itself
+                        # (not handled by _execute_task_repetition) — record it with the
+                        # canonical report schema and carry on with the remaining tasks.
+                        report = self._build_report(
+                            task,
+                            repeat_idx,
+                            TaskExecutionStatus.UNKNOWN_EXECUTION_ERROR,
+                            error={
                                 "error_type": type(e).__name__,
                                 "error_message": str(e),
                                 "traceback": "".join(traceback.format_exception(type(e), e, e.__traceback__)),
                             },
-                            "traces": {},
-                            "config": {},
-                            "eval": None,
-                        }
+                        )
 
                     self._append_report_safe(report)
 
@@ -1447,20 +1495,27 @@ class Benchmark(ABC):
                 model parameters, agent architecture details, and tool specifications.
 
         Returns:
-            List of report dictionaries, one per task repetition. Each report contains:
+            List of report dictionaries, one per task repetition. Every report carries the
+            same keys (consistent schema) regardless of success or failure:
             - task_id: Task identifier (UUID)
             - repeat_idx: Repetition index (0 to n_task_repeats-1)
             - status: Execution status (one of TaskExecutionStatus enum values)
-            - traces: Execution traces from all registered components
-            - config: Configuration from all registered components and benchmark level
+            - traces: Execution traces from all registered components (``{}`` if unavailable, e.g. setup failure)
+            - config: Configuration from all registered components and benchmark level (``{}`` if unavailable)
+            - usage: Aggregated usage from all registered components (``None`` if not collected)
             - eval: Evaluation results (None if task or evaluation failed)
-            - error: Error details dict (only present if status is not SUCCESS), containing:
+            - task: Task summary dict with ``query``, ``metadata``, and ``protocol``
+            - error: Error details dict — ``None`` only when status is SUCCESS; otherwise always populated, containing:
                 - error_type: Exception class name
                 - error_message: Exception message
                 - traceback: Full traceback string
+                - (plus any error-specific extras, e.g. ``component``, ``elapsed``, ``timeout``)
 
         Raises:
             ValueError: If agent_data length doesn't match number of tasks (when agent_data is an iterable).
+            Exception: If a ``fail_on_setup_error`` / ``fail_on_task_error`` / ``fail_on_evaluation_error``
+                flag is set and the corresponding failure occurs, the original exception is re-raised
+                and the run is aborted (this applies to both sequential and parallel execution).
 
         How to use:
             This is the framework's main orchestration method that runs your entire benchmark. It

--- a/tests/test_core/test_benchmark/test_report_schema.py
+++ b/tests/test_core/test_benchmark/test_report_schema.py
@@ -1,0 +1,281 @@
+"""Tests for report-schema consistency across the whole task lifecycle.
+
+Every report a benchmark produces — whether the task succeeded or failed in
+setup, execution, or evaluation, and whether it ran sequentially or in
+parallel — must carry the same set of top-level keys so downstream consumers
+can rely on a stable schema. When a task did not succeed, ``report["error"]``
+must always be populated. In addition, when a ``fail_on_*`` flag is set a
+parallel run must abort just like a sequential one (it must not silently
+swallow the failure and keep going).
+"""
+
+import time
+
+import pytest
+
+from maseval import (
+    AgentAdapter,
+    Evaluator,
+    Task,
+    TaskExecutionStatus,
+    TaskQueue,
+)
+from maseval.core.task import TaskProtocol
+from conftest import DummyBenchmark
+
+
+# Canonical top-level keys every report must carry.
+REPORT_KEYS = {"task_id", "repeat_idx", "status", "error", "traces", "config", "usage", "eval", "task"}
+ERROR_KEYS = {"error_type", "error_message", "traceback"}
+
+
+def assert_canonical_schema(report):
+    """Assert a single report carries the canonical schema."""
+    missing = REPORT_KEYS - set(report.keys())
+    assert not missing, f"report is missing keys: {missing}"
+
+    # The ``task`` block is always present and structured.
+    assert isinstance(report["task"], dict)
+    assert {"query", "metadata", "protocol"} <= set(report["task"].keys())
+
+    # ``traces`` / ``config`` are always dicts (never absent / None).
+    assert isinstance(report["traces"], dict)
+    assert isinstance(report["config"], dict)
+
+    # ``error`` is None exactly when the task succeeded; otherwise it is populated.
+    if report["status"] == TaskExecutionStatus.SUCCESS.value:
+        assert report["error"] is None
+    else:
+        assert report["error"] is not None, f"status={report['status']!r} but error is None"
+        assert ERROR_KEYS <= set(report["error"].keys())
+
+
+# --------------------------------------------------------------------------
+# Failure-injection benchmarks
+# --------------------------------------------------------------------------
+
+
+class _FailingAgent:
+    def run(self, query: str) -> str:
+        raise RuntimeError("agent boom")
+
+
+class _FailingAgentAdapter(AgentAdapter):
+    def _run_agent(self, query: str) -> str:
+        return self.agent.run(query)
+
+
+class SetupFailureBenchmark(DummyBenchmark):
+    def setup_environment(self, agent_data, task, seed_generator):
+        raise RuntimeError("setup boom")
+
+
+class SelectiveSetupFailureBenchmark(DummyBenchmark):
+    """Fails ``setup_environment`` only for tasks whose query starts with ``fail``."""
+
+    def setup_environment(self, agent_data, task, seed_generator):
+        if task.query.startswith("fail"):
+            raise RuntimeError("setup boom")
+        return super().setup_environment(agent_data, task, seed_generator)
+
+
+class SetupTimeoutBenchmark(DummyBenchmark):
+    def setup_environment(self, agent_data, task, seed_generator):
+        time.sleep(0.05)
+        return super().setup_environment(agent_data, task, seed_generator)
+
+
+class ExecutionFailureBenchmark(DummyBenchmark):
+    def setup_agents(self, agent_data, environment, task, user, seed_generator):
+        adapter = _FailingAgentAdapter(_FailingAgent(), "failing_agent")
+        return [adapter], {"failing_agent": adapter}
+
+
+class _FailingEvaluator(Evaluator):
+    def filter_traces(self, traces):
+        return traces
+
+    def __call__(self, traces, final_answer=None):
+        raise ValueError("eval boom")
+
+
+class EvaluationFailureBenchmark(DummyBenchmark):
+    def setup_evaluators(self, environment, task, agents, user, seed_generator):
+        return [_FailingEvaluator(task, environment, user)]
+
+
+class UnexpectedWorkerFailureBenchmark(DummyBenchmark):
+    """Simulates a failure escaping ``_execute_task_repetition``'s own handling.
+
+    This is the only case ``_run_parallel`` should turn into a degraded report
+    on its own (and only when no ``fail_on_*`` flag is set).
+    """
+
+    def _execute_task_repetition(self, task, agent_data, repeat_idx):
+        if task.query == "boom":
+            raise RuntimeError("worker exploded")
+        return super()._execute_task_repetition(task, agent_data, repeat_idx)
+
+
+# name -> (benchmark class, expected status, task timeout_seconds or None)
+SCENARIOS = {
+    "success": (DummyBenchmark, TaskExecutionStatus.SUCCESS, None),
+    "setup_failure": (SetupFailureBenchmark, TaskExecutionStatus.SETUP_FAILED, None),
+    "setup_timeout": (SetupTimeoutBenchmark, TaskExecutionStatus.TASK_TIMEOUT, 0.001),
+    "execution_failure": (ExecutionFailureBenchmark, TaskExecutionStatus.UNKNOWN_EXECUTION_ERROR, None),
+    "evaluation_failure": (EvaluationFailureBenchmark, TaskExecutionStatus.EVALUATION_FAILED, None),
+}
+
+
+def _one_task(timeout_seconds=None):
+    if timeout_seconds is None:
+        return TaskQueue.from_list([{"query": "q", "environment_data": {}}])
+    return TaskQueue([Task(query="q", environment_data={}, protocol=TaskProtocol(timeout_seconds=timeout_seconds))])
+
+
+def _many_tasks(n=4):
+    return TaskQueue.from_list([{"query": f"q{i}", "environment_data": {}} for i in range(n)])
+
+
+# --------------------------------------------------------------------------
+# Schema-invariance tests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("num_workers", [1, 2], ids=["sequential", "parallel"])
+@pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
+def test_report_schema_consistent_across_lifecycle_outcomes(scenario, num_workers):
+    """Reports carry the canonical schema regardless of where (or whether) a task failed."""
+    benchmark_cls, expected_status, timeout = SCENARIOS[scenario]
+    benchmark = benchmark_cls(num_workers=num_workers)
+
+    reports = benchmark.run(_one_task(timeout), agent_data={"model": "test"})
+
+    assert len(reports) == 1
+    report = reports[0]
+    assert report["status"] == expected_status.value
+    assert_canonical_schema(report)
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("num_workers", [1, 2], ids=["sequential", "parallel"])
+def test_mixed_outcomes_in_one_run_all_share_schema(num_workers):
+    """A run mixing successes and a (graceful) setup failure still yields uniform reports."""
+    benchmark = SelectiveSetupFailureBenchmark(num_workers=num_workers)
+    tasks = TaskQueue.from_list(
+        [
+            {"query": "ok1", "environment_data": {}},
+            {"query": "fail-me", "environment_data": {}},
+            {"query": "ok2", "environment_data": {}},
+        ]
+    )
+
+    reports = benchmark.run(tasks, agent_data={"model": "test"})
+
+    assert len(reports) == 3
+    for report in reports:
+        assert_canonical_schema(report)
+
+    statuses = sorted(r["status"] for r in reports)
+    assert statuses == sorted(
+        [
+            TaskExecutionStatus.SUCCESS.value,
+            TaskExecutionStatus.SETUP_FAILED.value,
+            TaskExecutionStatus.SUCCESS.value,
+        ]
+    )
+
+
+@pytest.mark.core
+def test_parallel_fallback_unexpected_worker_failure_produces_full_schema_report():
+    """When a worker raises unexpectedly (no fail_on_* set), the parallel runner records a full-schema report and carries on."""
+    benchmark = UnexpectedWorkerFailureBenchmark(num_workers=2)
+    tasks = TaskQueue.from_list(
+        [
+            {"query": "ok1", "environment_data": {}},
+            {"query": "boom", "environment_data": {}},
+            {"query": "ok2", "environment_data": {}},
+        ]
+    )
+
+    reports = benchmark.run(tasks, agent_data={"model": "test"})
+
+    assert len(reports) == 3
+    for report in reports:
+        assert_canonical_schema(report)
+
+    boom_reports = [r for r in reports if r["status"] == TaskExecutionStatus.UNKNOWN_EXECUTION_ERROR.value]
+    assert len(boom_reports) == 1
+    assert "worker exploded" in boom_reports[0]["error"]["error_message"]
+    assert boom_reports[0]["error"]["error_type"] == "RuntimeError"
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("num_workers", [1, 2], ids=["sequential", "parallel"])
+def test_error_always_populated_when_status_not_success(num_workers):
+    """Whenever a report's status is not SUCCESS, ``report["error"]`` is populated."""
+    for benchmark_cls, expected_status, timeout in SCENARIOS.values():
+        benchmark = benchmark_cls(num_workers=num_workers)
+        reports = benchmark.run(_one_task(timeout), agent_data={"model": "test"})
+        report = reports[0]
+        if report["status"] == TaskExecutionStatus.SUCCESS.value:
+            assert report["error"] is None
+        else:
+            assert report["error"] is not None
+            assert report["error"]["error_message"]
+
+
+# --------------------------------------------------------------------------
+# Parallel fail-fast tests (must match sequential semantics)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.core
+def test_parallel_run_aborts_on_fail_on_task_error():
+    """fail_on_task_error=True aborts a parallel run instead of swallowing the failure."""
+    benchmark = ExecutionFailureBenchmark(num_workers=2, fail_on_task_error=True)
+    with pytest.raises(RuntimeError, match="agent boom"):
+        benchmark.run(_many_tasks(), agent_data={"model": "test"})
+
+
+@pytest.mark.core
+def test_parallel_run_aborts_on_fail_on_evaluation_error():
+    """fail_on_evaluation_error=True aborts a parallel run instead of swallowing the failure."""
+    benchmark = EvaluationFailureBenchmark(num_workers=2, fail_on_evaluation_error=True)
+    with pytest.raises(ValueError, match="eval boom"):
+        benchmark.run(_many_tasks(), agent_data={"model": "test"})
+
+
+@pytest.mark.core
+def test_parallel_run_aborts_on_fail_on_setup_error():
+    """fail_on_setup_error=True aborts a parallel run instead of swallowing the failure."""
+    benchmark = SetupFailureBenchmark(num_workers=2, fail_on_setup_error=True)
+    with pytest.raises(RuntimeError, match="setup boom"):
+        benchmark.run(_many_tasks(), agent_data={"model": "test"})
+
+
+@pytest.mark.core
+def test_parallel_unexpected_worker_failure_propagates_when_fail_fast():
+    """An unexpected worker failure also aborts a parallel run when a fail_on_* flag is set."""
+    benchmark = UnexpectedWorkerFailureBenchmark(num_workers=2, fail_on_task_error=True)
+    tasks = TaskQueue.from_list(
+        [
+            {"query": "ok1", "environment_data": {}},
+            {"query": "boom", "environment_data": {}},
+        ]
+    )
+    with pytest.raises(RuntimeError, match="worker exploded"):
+        benchmark.run(tasks, agent_data={"model": "test"})
+
+
+@pytest.mark.core
+def test_parallel_graceful_failure_keeps_running_with_full_schema():
+    """With fail_on_* unset, a failed task yields a full-schema report and the run continues."""
+    benchmark = ExecutionFailureBenchmark(num_workers=2, fail_on_task_error=False)
+    reports = benchmark.run(_many_tasks(), agent_data={"model": "test"})
+
+    assert len(reports) == 4
+    for report in reports:
+        assert_canonical_schema(report)
+        assert report["status"] == TaskExecutionStatus.UNKNOWN_EXECUTION_ERROR.value


### PR DESCRIPTION
## Description

`Benchmark.run()` documents a stable report schema, but it wasn't actually stable. Reports built on the setup-failure and setup-timeout early returns, and on the `except Exception` fallback in `_run_parallel`, were missing the `usage` and `task` keys (and had empty `traces`/`config`), so a row that failed in setup looked structurally different from a row that succeeded, breaking any consumer that indexes `report["task"]` / `report["usage"]` on every row. Separately, in parallel runs the `fail_on_setup_error` / `fail_on_task_error` / `fail_on_evaluation_error` flags were effectively no-ops: when `_execute_task_repetition` re-raised, `_run_parallel` swallowed the exception into a degraded report and kept going, instead of aborting the run the way a sequential run does.

This PR makes every report carry the same keys regardless of outcome, and makes parallel fail-fast behave like sequential fail-fast.

### What changed

- New `Benchmark._build_report(...)`: the single constructor for repetition reports. Every report (success, setup failure, setup timeout, agent/environment/user/unknown execution error, evaluation failure, or an unexpected worker failure in parallel mode) now always contains `task_id`, `repeat_idx`, `status`, `error`, `traces`, `config`, `usage`, `eval`, `task`. `traces`/`config` default to `{}` when unavailable; `error` is `None` only for `SUCCESS` and is otherwise always populated (a generic placeholder is synthesised as a backstop if a caller ever omits it).
- `_run_parallel` now re-raises (and shuts the pool down, cancelling queued work) when a worker future raises and any `fail_on_*` flag is set — aborting the run like `_run_sequential`. Only genuinely unexpected worker failures (no `fail_on_*` set) are turned into a degraded-but-full-schema `UNKNOWN_EXECUTION_ERROR` report so the rest of the batch continues.
- Updated the `run()` docstring (Returns/Raises) to describe the full schema and the fail-fast behaviour.

### Tests

New `tests/test_core/test_benchmark/test_report_schema.py`:

- Schema invariance over `{success, setup_failure, setup_timeout, execution_failure, evaluation_failure} × {sequential, parallel}`, plus a mixed-outcome run and an "`error` always populated when `status != SUCCESS`" check.
- Parallel runs abort on each of `fail_on_setup_error` / `fail_on_task_error` / `fail_on_evaluation_error`.
- An unexpected worker failure yields a full-schema degraded report (graceful mode) and propagates when a `fail_on_*` flag is set.

11 of these were red before the fix. `just all` is green (ruff format + check, `ty check maseval tests`, full default + offline suites — 2631 passed, 1 skipped, 2 xfailed).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, formatting, etc.)

## Checklist

### Contribution

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] Added/updated docstrings for new/modified functions as instructed [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Updated relevant documentation in `docs/` (if applicable)
- [ ] Tag github issue with this PR (if applicable)

### Changelog

- [x] Added entry to `CHANGELOG.md` under `[Unreleased]` section
  - Use **Added** section for new features
  - Use **Changed** section for modifications to existing functionality
  - Use **Fixed** section for bug fixes
  - Use **Removed** section for deprecated/removed features
- [ ] OR this is a documentation-only change (no changelog needed)

### Architecture (if applicable)

- [x] Core/Interface separation: Changes in `maseval/core/` do NOT import from `maseval/interface/`
- [x] Dependencies: New core dependencies added sparingly; framework integrations go to optional dependencies

## Additional Notes

Behaviour change worth flagging for reviewers: under `num_workers > 1`, a `fail_on_*` flag now aborts the run (re-raising the original exception) instead of being silently absorbed into a report. This matches the documented intent and the sequential path; anyone who was (perhaps unknowingly) relying on the old swallow-and-continue behaviour in parallel mode should set the flag to `False` and inspect report `status` instead.

Adding keys to the report dict is additive and shouldn't break consumers that look up keys by name; consumers that asserted on the exact key set will see the two new keys (`usage`, `task`) on previously-degraded rows.