### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.5.0] - 2026-07-05
+
+### Added
+
 - Generic `AREEnvironment` in `maseval.interface.environments` for Meta's ARE (Agent Research Environments) platform with lifecycle control (start/stop/pause/resume), notification polling, AUI tool filtering, and oracle mode support. Install with `pip install maseval[are]`. (PR: #55)
 - Generic `AREToolWrapper` in `maseval.interface.environments` wraps any ARE `AppTool` with simulation time tracking, invocation history, JSON schema extraction, and MASEval tracing integration. (PR: #55)
 - Optional dependency extra `are`: `pip install maseval[are]` (PR: #55)
@@ -361,7 +371,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Previous changes here -->
 
-[Unreleased]: https://github.com/parameterlab/maseval/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/parameterlab/maseval/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/parameterlab/maseval/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/parameterlab/maseval/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/parameterlab/maseval/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/parameterlab/maseval/compare/v0.1.2...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maseval"
-version = "0.4.0"
+version = "0.5.0"
 description = "A library for multi-agent systems evaluation and benchmarking."
 authors = [{ name = "Cornelius Emde", email = "cornelius@parameterlab.de" }]
 readme = "README.md"


### PR DESCRIPTION
## Description

Release PR for **v0.5.0**. This bumps the version in `pyproject.toml` (0.4.0 → 0.5.0) and finalizes `CHANGELOG.md` by promoting the `[Unreleased]` section to `[0.5.0] - 2026-07-05` (with a fresh empty `[Unreleased]` and updated compare links). No source changes are in this PR itself — the feature/fix work already landed in the PRs referenced below.

Once merged into `main`, pushing the signed `v0.5.0` tag triggers the "Release to PyPI" workflow (build + trusted publishing + GitHub Release).

**What's in 0.5.0:**

- **Added** — Generic `AREEnvironment` and `AREToolWrapper` for Meta's ARE (Agent Research Environments) platform, plus a new `are` optional extra (`pip install maseval[are]`). (#55)
- **Changed** — `Gaia2Environment` now inherits from `AREEnvironment`; `Gaia2GenericTool` is an alias for `AREToolWrapper` (#55). ⚠️ **Breaking:** `task_data` constructor parameter renamed to `environment_data` across all environments, fixtures, and examples (#58).
- **Fixed** — MACS real-data test data shape (#58); consistent `Benchmark.run()` report schema across all outcomes and `fail_on_*` aborting parallel runs (#61); judge/evaluator token usage now captured in per-task reports and aggregate usage (#63).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvement (refactoring, formatting, etc.)

<!-- This PR's diff is only a version bump + changelog; the 0.5.0 release it cuts includes the breaking `task_data` → `environment_data` rename (#58). -->

## Checklist

### Contribution

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] Added/updated docstrings for new/modified functions as instructed [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Updated relevant documentation in `docs/` (if applicable)
- [ ] Tag github issue with this PR (if applicable)

### Changelog

- [x] Added entry to `CHANGELOG.md` under `[Unreleased]` section
  - Use **Added** section for new features
  - Use **Changed** section for modifications to existing functionality
  - Use **Fixed** section for bug fixes
  - Use **Removed** section for deprecated/removed features
- [ ] OR this is a documentation-only change (no changelog needed)

### Architecture (if applicable)

- [x] Core/Interface separation: Changes in `maseval/core/` do NOT import from `maseval/interface/`
- [x] Dependencies: New core dependencies added sparingly; framework integrations go to optional dependencies

## Additional Notes

- Version tag `v0.5.0` is signed and already points at the bump commit; do not push it until this PR merges into `main`.
- The `environment_data` rename (#58) is a breaking API change — downstream callers constructing environments with `task_data=` must update to `environment_data=`.
