### PR TITLE
chore: update repository URLs from parameterlab to maseval org

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -15,7 +15,7 @@ git push && git push --tags
 
 The script automatically stages `CHANGELOG.md` along with `pyproject.toml`.
 
-Automation handles the rest: https://github.com/parameterlab/maseval/actions
+Automation handles the rest: https://github.com/maseval/maseval/actions
 
 ---
 

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -15,7 +15,7 @@ git push && git push --tags
 
 The script automatically stages `CHANGELOG.md` along with `pyproject.toml`.
 
-Automation handles the rest: https://github.com/maseval/maseval/actions
+Automation handles the rest: https://github.com/maseval/MASEval/actions
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,10 +371,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Previous changes here -->
 
-[Unreleased]: https://github.com/maseval/maseval/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/maseval/maseval/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/maseval/maseval/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/maseval/maseval/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/maseval/maseval/compare/v0.1.2...v0.2.0
-[0.1.2]: https://github.com/maseval/maseval/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/maseval/maseval/releases/tag/v0.1.1
+[Unreleased]: https://github.com/maseval/MASEval/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/maseval/MASEval/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/maseval/MASEval/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/maseval/MASEval/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/maseval/MASEval/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/maseval/MASEval/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/maseval/MASEval/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,10 +371,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Previous changes here -->
 
-[Unreleased]: https://github.com/parameterlab/maseval/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/parameterlab/maseval/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/parameterlab/maseval/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/parameterlab/maseval/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/parameterlab/maseval/compare/v0.1.2...v0.2.0
-[0.1.2]: https://github.com/parameterlab/maseval/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/parameterlab/maseval/releases/tag/v0.1.1
+[Unreleased]: https://github.com/maseval/maseval/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/maseval/maseval/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/maseval/maseval/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/maseval/maseval/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/maseval/maseval/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/maseval/maseval/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/maseval/maseval/releases/tag/v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ mkdocs serve
 API reference pages should include links to source files on GitHub. Use the following pattern:
 
 ```markdown
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/path/to/YOUR_NEW_CLASS.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/path/to/YOUR_NEW_CLASS.py){ .md-source-file align=right }
 
 ::: maseval.path.to.YOUR_NEW_CLASS
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ mkdocs serve
 API reference pages should include links to source files on GitHub. Use the following pattern:
 
 ```markdown
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/path/to/YOUR_NEW_CLASS.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/path/to/YOUR_NEW_CLASS.py){ .md-source-file align=right }
 
 ::: maseval.path.to.YOUR_NEW_CLASS
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/parameterlab/MASEval/refs/heads/main/assets/logo-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/parameterlab/MASEval/refs/heads/main/assets/logo-light.svg">
-    <img src="https://raw.githubusercontent.com/parameterlab/MASEval/refs/heads/main/assets/logo-light.svg" alt="MASEval logo" width="240" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/maseval/MASEval/refs/heads/main/assets/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/maseval/MASEval/refs/heads/main/assets/logo-light.svg">
+    <img src="https://raw.githubusercontent.com/maseval/MASEval/refs/heads/main/assets/logo-light.svg" alt="MASEval logo" width="240" />
   </picture>
 </p>
 
@@ -12,8 +12,8 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://badge.fury.io/py/maseval.svg)](https://badge.fury.io/py/maseval)
 [![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://maseval.readthedocs.io/en/stable/)
-[![Tests](https://github.com/parameterlab/MASEval/actions/workflows/test.yml/badge.svg)](https://github.com/parameterlab/MASEval/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/parameterlab/MASEval/graph/badge.svg?token=HMFU71QVB2)](https://codecov.io/gh/parameterlab/MASEval)
+[![Tests](https://github.com/maseval/MASEval/actions/workflows/test.yml/badge.svg)](https://github.com/maseval/MASEval/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/maseval/MASEval/graph/badge.svg?token=HMFU71QVB2)](https://codecov.io/gh/maseval/MASEval)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 MASEval is an evaluation library that provides a unified interface for benchmarking (multi-)agent systems. It offers standardized abstractions for running any agent implementation—whether built with AutoGen, LangChain, custom frameworks, or direct API calls—against established benchmarks like GAIA and AgentBench, or your own custom evaluation tasks.

--- a/docs/benchmark/converse.md
+++ b/docs/benchmark/converse.md
@@ -139,7 +139,7 @@ Output fields:
 - `coverage_evaluation` (dict): Full LLM coverage evaluation.
 - `ratings_evaluation` (dict): Full LLM ratings evaluation with `ratings_mapping` and `average_rating`.
 
-[:material-github: View source](https://github.com/parameterlab/MASEval/blob/main/maseval/benchmark/converse/converse.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/benchmark/converse/converse.py){ .md-source-file }
 
 ::: maseval.benchmark.converse.ConverseBenchmark
 

--- a/docs/benchmark/gaia2.md
+++ b/docs/benchmark/gaia2.md
@@ -17,7 +17,7 @@ The **GAIA2 Benchmark** evaluates LLM-based agents on dynamic, multi-step scenar
 
 Reference Paper: "GAIA-2: A Controllable Multi-Turn Conversational Benchmark for Agents"
 
-Check out the [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
+Check out the [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
 
 ## Installation
 

--- a/docs/benchmark/index.md
+++ b/docs/benchmark/index.md
@@ -13,4 +13,4 @@ You can also create your own benchmarks by subclassing the [`Benchmark`](../refe
 
 ## Licensing
 
-For detailed source and licensing information for each benchmark's data, see [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md).
+For detailed source and licensing information for each benchmark's data, see [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md).

--- a/docs/benchmark/macs.md
+++ b/docs/benchmark/macs.md
@@ -6,7 +6,7 @@ The **Multi-Agent Collaboration Scenarios (MACS)** benchmark evaluates how well 
 
 [Multi-Agent Collaboration Scenarios (MACS)](https://arxiv.org/abs/2412.05449) is designed to test collaborative problem-solving in realistic enterprise scenarios. The benchmark includes tasks spanning multiple domains such as travel planning, retail, and more. Each task involves multiple agents that must coordinate their actions to achieve user goals.
 
-Check out the [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
+Check out the [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
 
 ## Quick Start
 

--- a/docs/benchmark/mmlu.md
+++ b/docs/benchmark/mmlu.md
@@ -14,7 +14,7 @@ The **MMLU Benchmark** evaluates language models on multiple-choice questions sp
 - **HuggingFace integration** with batched log-probability computation
 - **lm-eval compatibility** mode for exact numerical reproduction
 
-Check out the [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
+Check out the [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
 
 ## Installation
 

--- a/docs/benchmark/multiagentbench.md
+++ b/docs/benchmark/multiagentbench.md
@@ -14,7 +14,7 @@ The **MultiAgentBench** benchmark evaluates multi-agent collaboration and compet
 
 Reference Paper: [MultiAgentBench: Evaluating the Collaboration and Competition of LLM agents](https://arxiv.org/abs/2503.01935)
 
-Check out the [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
+Check out the [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
 
 ::: maseval.benchmark.multiagentbench.MultiAgentBenchBenchmark
 

--- a/docs/benchmark/tau2.md
+++ b/docs/benchmark/tau2.md
@@ -16,7 +16,7 @@ The **Tau2 Benchmark** evaluates LLM-based agents on customer service tasks acro
 
 Reference Paper: [Tau-Bench: A Benchmark for Tool-Agent-User Interaction in Real-World Domains](https://arxiv.org/abs/2406.12045)
 
-Check out the [BENCHMARKS.md](https://github.com/parameterlab/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
+Check out the [BENCHMARKS.md](https://github.com/maseval/MASEval/blob/main/BENCHMARKS.md) file for more information including licenses.
 
 ## Quick Start
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,5 +6,5 @@ Learn MASEval through hands-on examples covering common use cases and benchmarks
 | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | [Tutorial](tutorial.ipynb)                                                                                                                         | Introduction to MASEval's core concepts and basic usage |
 | [Five-a-Day Benchmark](five_a_day_benchmark.ipynb)                                                                                                 | Building a custom benchmark from scratch                |
-| [Multi-Agent Collaboration Scenario Benchmark (MACS)](https://github.com/parameterlab/MASEval/blob/main/examples/macs_benchmark/macs_benchmark.py) | An adaptation of the `maseval.benchmark.MACSBenchmark`. |
-| [CONVERSE (Default Agent)](https://github.com/parameterlab/MASEval/blob/main/examples/converse_benchmark/default_converse_benchmark.py)         | Run `DefaultAgentConverseBenchmark` end-to-end.         |
+| [Multi-Agent Collaboration Scenario Benchmark (MACS)](https://github.com/maseval/MASEval/blob/main/examples/macs_benchmark/macs_benchmark.py) | An adaptation of the `maseval.benchmark.MACSBenchmark`. |
+| [CONVERSE (Default Agent)](https://github.com/maseval/MASEval/blob/main/examples/converse_benchmark/default_converse_benchmark.py)         | Run `DefaultAgentConverseBenchmark` end-to-end.         |

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -11,8 +11,8 @@ Anyone! We had a few groups in mind when building MASEval.
 ## Q: I am looking for a specific feature, but I cannot find it.
 
 1. Check this documentation.
-2. If the feature does not exist, please [open an issue on GitHub](https://github.com/parameterlab/MASEval/issues/new). Feature requests are welcome.
-3. Consider implementing it yourself. Check out the [contributing guide](https://github.com/parameterlab/MASEval/blob/main/CONTRIBUTING.md) for details.
+2. If the feature does not exist, please [open an issue on GitHub](https://github.com/maseval/MASEval/issues/new). Feature requests are welcome.
+3. Consider implementing it yourself. Check out the [contributing guide](https://github.com/maseval/MASEval/blob/main/CONTRIBUTING.md) for details.
 
 ## Q: Can I only test multi-agent systems?
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -244,4 +244,4 @@ Formal API documentation for all MASEval components. The reference is split into
 
 ## Next Steps
 
-Work through the examples listed above. 3. **Explore the [`examples/five_a_day_benchmark/`](https://github.com/parameterlab/MASEval/tree/main/examples/five_a_day_benchmark) folder** for tool implementations, evaluators, and the CLI script (`five_a_day_benchmark.py`) 4. **Build your own benchmark** using the patterns you've learned
+Work through the examples listed above. 3. **Explore the [`examples/five_a_day_benchmark/`](https://github.com/maseval/MASEval/tree/main/examples/five_a_day_benchmark) folder** for tool implementations, evaluators, and the CLI script (`five_a_day_benchmark.py`) 4. **Build your own benchmark** using the patterns you've learned

--- a/docs/interface/agents/camel.md
+++ b/docs/interface/agents/camel.md
@@ -19,7 +19,7 @@ pip install camel-ai
 
 ## API Reference
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/camel.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/camel.py){ .md-source-file }
 
 ::: maseval.interface.agents.camel.CamelAgentAdapter
 

--- a/docs/interface/agents/camel.md
+++ b/docs/interface/agents/camel.md
@@ -19,7 +19,7 @@ pip install camel-ai
 
 ## API Reference
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/camel.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/camel.py){ .md-source-file }
 
 ::: maseval.interface.agents.camel.CamelAgentAdapter
 

--- a/docs/interface/agents/langgraph.md
+++ b/docs/interface/agents/langgraph.md
@@ -19,7 +19,7 @@ pip install langgraph
 
 ## API Reference
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file }
 
 ::: maseval.interface.agents.langgraph.LangGraphAgentAdapter
 

--- a/docs/interface/agents/langgraph.md
+++ b/docs/interface/agents/langgraph.md
@@ -19,7 +19,7 @@ pip install langgraph
 
 ## API Reference
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file }
 
 ::: maseval.interface.agents.langgraph.LangGraphAgentAdapter
 

--- a/docs/interface/agents/llamaindex.md
+++ b/docs/interface/agents/llamaindex.md
@@ -19,7 +19,7 @@ pip install llama-index-core
 
 ## API Reference
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file }
 
 ::: maseval.interface.agents.llamaindex.LlamaIndexAgentAdapter
 

--- a/docs/interface/agents/llamaindex.md
+++ b/docs/interface/agents/llamaindex.md
@@ -19,7 +19,7 @@ pip install llama-index-core
 
 ## API Reference
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file }
 
 ::: maseval.interface.agents.llamaindex.LlamaIndexAgentAdapter
 

--- a/docs/interface/agents/smolagents.md
+++ b/docs/interface/agents/smolagents.md
@@ -19,12 +19,12 @@ pip install smolagents
 
 ## API Reference
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file }
 
 ::: maseval.interface.agents.smolagents.SmolAgentAdapter
 
 ::: maseval.interface.agents.smolagents.SmolAgentLLMUser
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents_optional.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/smolagents_optional.py){ .md-source-file }
 
 ::: maseval.interface.agents.smolagents_optional.SmolAgentUserSimulationInputTool

--- a/docs/interface/agents/smolagents.md
+++ b/docs/interface/agents/smolagents.md
@@ -19,12 +19,12 @@ pip install smolagents
 
 ## API Reference
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file }
 
 ::: maseval.interface.agents.smolagents.SmolAgentAdapter
 
 ::: maseval.interface.agents.smolagents.SmolAgentLLMUser
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/smolagents_optional.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents_optional.py){ .md-source-file }
 
 ::: maseval.interface.agents.smolagents_optional.SmolAgentUserSimulationInputTool

--- a/docs/interface/environments/are.md
+++ b/docs/interface/environments/are.md
@@ -19,7 +19,7 @@ pip install meta-agents-research-environments
 
 ## API Reference
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/environments/are.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/environments/are.py){ .md-source-file }
 
 ::: maseval.interface.environments.are.AREEnvironment
 

--- a/docs/interface/environments/are.md
+++ b/docs/interface/environments/are.md
@@ -19,7 +19,7 @@ pip install meta-agents-research-environments
 
 ## API Reference
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/environments/are.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/environments/are.py){ .md-source-file }
 
 ::: maseval.interface.environments.are.AREEnvironment
 

--- a/docs/interface/inference/anthropic.md
+++ b/docs/interface/inference/anthropic.md
@@ -2,6 +2,6 @@
 
 This page documents the [Anthropic](https://docs.anthropic.com/) model adapter for MASEval.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
 
 ::: maseval.interface.inference.anthropic.AnthropicModelAdapter

--- a/docs/interface/inference/anthropic.md
+++ b/docs/interface/inference/anthropic.md
@@ -2,6 +2,6 @@
 
 This page documents the [Anthropic](https://docs.anthropic.com/) model adapter for MASEval.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
 
 ::: maseval.interface.inference.anthropic.AnthropicModelAdapter

--- a/docs/interface/inference/google_genai.md
+++ b/docs/interface/inference/google_genai.md
@@ -2,6 +2,6 @@
 
 This page documents the Google GenAI model adapter for MASEval.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
 
 ::: maseval.interface.inference.google_genai.GoogleGenAIModelAdapter

--- a/docs/interface/inference/google_genai.md
+++ b/docs/interface/inference/google_genai.md
@@ -2,6 +2,6 @@
 
 This page documents the Google GenAI model adapter for MASEval.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
 
 ::: maseval.interface.inference.google_genai.GoogleGenAIModelAdapter

--- a/docs/interface/inference/huggingface.md
+++ b/docs/interface/inference/huggingface.md
@@ -4,12 +4,12 @@ This page documents the HuggingFace model adapters for MASEval.
 
 ## Pipeline Model Adapter (Text Generation)
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface.HuggingFacePipelineModelAdapter
 
 ## Model Scorer (Log-Likelihood)
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface_scorer.HuggingFaceModelScorer

--- a/docs/interface/inference/huggingface.md
+++ b/docs/interface/inference/huggingface.md
@@ -4,12 +4,12 @@ This page documents the HuggingFace model adapters for MASEval.
 
 ## Pipeline Model Adapter (Text Generation)
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface.HuggingFacePipelineModelAdapter
 
 ## Model Scorer (Log-Likelihood)
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface_scorer.HuggingFaceModelScorer

--- a/docs/interface/inference/litellm.md
+++ b/docs/interface/inference/litellm.md
@@ -2,6 +2,6 @@
 
 This page documents the [LiteLLM](https://docs.litellm.ai/docs/) model adapter for MASEval.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
 
 ::: maseval.interface.inference.litellm.LiteLLMModelAdapter

--- a/docs/interface/inference/litellm.md
+++ b/docs/interface/inference/litellm.md
@@ -2,6 +2,6 @@
 
 This page documents the [LiteLLM](https://docs.litellm.ai/docs/) model adapter for MASEval.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
 
 ::: maseval.interface.inference.litellm.LiteLLMModelAdapter

--- a/docs/interface/inference/openai.md
+++ b/docs/interface/inference/openai.md
@@ -3,6 +3,6 @@
 This page documents the OpenAI model adapter that implements MASEval's
 ModelAdapter interface for OpenAI's API.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
 
 ::: maseval.interface.inference.openai.OpenAIModelAdapter

--- a/docs/interface/inference/openai.md
+++ b/docs/interface/inference/openai.md
@@ -3,6 +3,6 @@
 This page documents the OpenAI model adapter that implements MASEval's
 ModelAdapter interface for OpenAI's API.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
 
 ::: maseval.interface.inference.openai.OpenAIModelAdapter

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -2,7 +2,7 @@
 
 Agent adapters wrap agents from any framework to provide a unified interface for benchmarking. They handle execution, message history tracking, and callback hooks.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/agent.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/agent.py){ .md-source-file align=right }
 
 ::: maseval.core.agent.AgentAdapter
 options:
@@ -12,14 +12,14 @@ show_source: false
 
 Adapters that integrate MASEval with agent frameworks:
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.smolagents.SmolAgentAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.langgraph.LangGraphAgentAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.llamaindex.LlamaIndexAgentAdapter

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -2,7 +2,7 @@
 
 Agent adapters wrap agents from any framework to provide a unified interface for benchmarking. They handle execution, message history tracking, and callback hooks.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/agent.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/agent.py){ .md-source-file align=right }
 
 ::: maseval.core.agent.AgentAdapter
 options:
@@ -12,14 +12,14 @@ show_source: false
 
 Adapters that integrate MASEval with agent frameworks:
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/smolagents.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.smolagents.SmolAgentAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/langgraph.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.langgraph.LangGraphAgentAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file align=right }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/agents/llamaindex.py){ .md-source-file align=right }
 
 ::: maseval.interface.agents.llamaindex.LlamaIndexAgentAdapter

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -6,7 +6,7 @@ Think of it as the experiment controller: you describe _what_ to set up and _how
 
 Each method below is documented starting with the formal method definition and a following `How to use` section that is more educational and should help getting started.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/benchmark.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/benchmark.py){ .md-source-file }
 
 ::: maseval.core.benchmark.Benchmark
 

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -6,7 +6,7 @@ Think of it as the experiment controller: you describe _what_ to set up and _how
 
 Each method below is documented starting with the formal method definition and a following `How to use` section that is more educational and should help getting started.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/benchmark.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/benchmark.py){ .md-source-file }
 
 ::: maseval.core.benchmark.Benchmark
 

--- a/docs/reference/callback.md
+++ b/docs/reference/callback.md
@@ -2,7 +2,7 @@
 
 Callbacks allow you to hook into benchmark execution at various points. Use them for logging, monitoring, tracing, or custom side effects during agent runs.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/callback.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callback.py){ .md-source-file }
 
 ::: maseval.core.callback.BenchmarkCallback
 
@@ -16,13 +16,13 @@ MASEval provides built-in callback implementations:
 
 ### Message Tracing
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/callbacks/message_tracing.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/message_tracing.py){ .md-source-file }
 
 ::: maseval.core.callbacks.message_tracing.MessageTracingAgentCallback
 
 ### Result Logging
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/callbacks/result_logger.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/result_logger.py){ .md-source-file }
 
 ::: maseval.core.callbacks.result_logger.ResultLogger
 
@@ -30,7 +30,7 @@ MASEval provides built-in callback implementations:
 
 ### Progress Bars
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/callbacks/progress_bar.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/progress_bar.py){ .md-source-file }
 
 ::: maseval.core.callbacks.progress_bar.ProgressBarCallback
 

--- a/docs/reference/callback.md
+++ b/docs/reference/callback.md
@@ -2,7 +2,7 @@
 
 Callbacks allow you to hook into benchmark execution at various points. Use them for logging, monitoring, tracing, or custom side effects during agent runs.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callback.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/callback.py){ .md-source-file }
 
 ::: maseval.core.callback.BenchmarkCallback
 
@@ -16,13 +16,13 @@ MASEval provides built-in callback implementations:
 
 ### Message Tracing
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/message_tracing.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/callbacks/message_tracing.py){ .md-source-file }
 
 ::: maseval.core.callbacks.message_tracing.MessageTracingAgentCallback
 
 ### Result Logging
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/result_logger.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/callbacks/result_logger.py){ .md-source-file }
 
 ::: maseval.core.callbacks.result_logger.ResultLogger
 
@@ -30,7 +30,7 @@ MASEval provides built-in callback implementations:
 
 ### Progress Bars
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/callbacks/progress_bar.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/callbacks/progress_bar.py){ .md-source-file }
 
 ::: maseval.core.callbacks.progress_bar.ProgressBarCallback
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -2,7 +2,7 @@
 
 Environments define the execution context for agents, including available tools, state, and any external resources needed during task execution.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/environment.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/environment.py){ .md-source-file }
 
 ::: maseval.core.environment.Environment
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -2,7 +2,7 @@
 
 Environments define the execution context for agents, including available tools, state, and any external resources needed during task execution.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/environment.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/environment.py){ .md-source-file }
 
 ::: maseval.core.environment.Environment
 

--- a/docs/reference/evaluator.md
+++ b/docs/reference/evaluator.md
@@ -2,6 +2,6 @@
 
 Evaluators assess agent performance after task completion. They compare agent outputs against expected results and return structured evaluation metrics.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/evaluator.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/evaluator.py){ .md-source-file }
 
 ::: maseval.core.evaluator.Evaluator

--- a/docs/reference/evaluator.md
+++ b/docs/reference/evaluator.md
@@ -2,6 +2,6 @@
 
 Evaluators assess agent performance after task completion. They compare agent outputs against expected results and return structured evaluation metrics.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/evaluator.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/evaluator.py){ .md-source-file }
 
 ::: maseval.core.evaluator.Evaluator

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -2,7 +2,7 @@
 
 Exception classes for error classification in benchmark execution.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/exceptions.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/exceptions.py){ .md-source-file }
 
 ## Exception Hierarchy
 

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -2,7 +2,7 @@
 
 Exception classes for error classification in benchmark execution.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/exceptions.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/exceptions.py){ .md-source-file }
 
 ## Exception Hierarchy
 

--- a/docs/reference/history.md
+++ b/docs/reference/history.md
@@ -2,7 +2,7 @@
 
 These are the objects used internally within each class to trace everything.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/history.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/history.py){ .md-source-file }
 
 ::: maseval.core.history.MessageHistory
 

--- a/docs/reference/history.md
+++ b/docs/reference/history.md
@@ -2,7 +2,7 @@
 
 These are the objects used internally within each class to trace everything.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/history.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/history.py){ .md-source-file }
 
 ::: maseval.core.history.MessageHistory
 

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -6,7 +6,7 @@ Model Adapters provide a uniform runtime interface to heterogeneous model provid
 
     `Benchmark` expects `AgentAdapter` instances; it does not consume model adapters directly. ModelAdapters are used by agents, simulators, others that directly invoke models.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/model.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/model.py){ .md-source-file }
 
 ::: maseval.core.model.ModelAdapter
 
@@ -14,22 +14,22 @@ Model Adapters provide a uniform runtime interface to heterogeneous model provid
 
 The following adapter classes implement the ModelAdapter interface for specific providers. Each requires their own dependencies.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
 
 ::: maseval.interface.inference.openai.OpenAIModelAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface.HuggingFacePipelineModelAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
 
 ::: maseval.interface.inference.google_genai.GoogleGenAIModelAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
 
 ::: maseval.interface.inference.litellm.LiteLLMModelAdapter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
 
 ::: maseval.interface.inference.anthropic.AnthropicModelAdapter

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -6,7 +6,7 @@ Model Adapters provide a uniform runtime interface to heterogeneous model provid
 
     `Benchmark` expects `AgentAdapter` instances; it does not consume model adapters directly. ModelAdapters are used by agents, simulators, others that directly invoke models.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/model.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/model.py){ .md-source-file }
 
 ::: maseval.core.model.ModelAdapter
 
@@ -14,22 +14,22 @@ Model Adapters provide a uniform runtime interface to heterogeneous model provid
 
 The following adapter classes implement the ModelAdapter interface for specific providers. Each requires their own dependencies.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/openai.py){ .md-source-file }
 
 ::: maseval.interface.inference.openai.OpenAIModelAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface.HuggingFacePipelineModelAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/google_genai.py){ .md-source-file }
 
 ::: maseval.interface.inference.google_genai.GoogleGenAIModelAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/litellm.py){ .md-source-file }
 
 ::: maseval.interface.inference.litellm.LiteLLMModelAdapter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/anthropic.py){ .md-source-file }
 
 ::: maseval.interface.inference.anthropic.AnthropicModelAdapter

--- a/docs/reference/scorer.md
+++ b/docs/reference/scorer.md
@@ -6,7 +6,7 @@ Model Scorers provide a uniform interface for log-likelihood computation across 
 
     `ModelScorer` is the scoring counterpart to `ModelAdapter`. Use it when you need log-likelihood evaluation (e.g., multiple-choice benchmarks) rather than text generation.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/scorer.py){ .md-source-file }
 
 ::: maseval.core.scorer.ModelScorer
 
@@ -14,6 +14,6 @@ Model Scorers provide a uniform interface for log-likelihood computation across 
 
 The following scorer classes implement the ModelScorer interface for specific providers.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface_scorer.HuggingFaceModelScorer

--- a/docs/reference/scorer.md
+++ b/docs/reference/scorer.md
@@ -6,7 +6,7 @@ Model Scorers provide a uniform interface for log-likelihood computation across 
 
     `ModelScorer` is the scoring counterpart to `ModelAdapter`. Use it when you need log-likelihood evaluation (e.g., multiple-choice benchmarks) rather than text generation.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/scorer.py){ .md-source-file }
 
 ::: maseval.core.scorer.ModelScorer
 
@@ -14,6 +14,6 @@ Model Scorers provide a uniform interface for log-likelihood computation across 
 
 The following scorer classes implement the ModelScorer interface for specific providers.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/inference/huggingface_scorer.py){ .md-source-file }
 
 ::: maseval.interface.inference.huggingface_scorer.HuggingFaceModelScorer

--- a/docs/reference/seeding.md
+++ b/docs/reference/seeding.md
@@ -8,14 +8,14 @@ The seeding module provides infrastructure for reproducible benchmark runs. Seed
 
 The abstract base class that defines the seeding interface. Implement this to create custom seeding strategies.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.SeedGenerator
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.DefaultSeedGenerator
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.SeedingError

--- a/docs/reference/seeding.md
+++ b/docs/reference/seeding.md
@@ -8,14 +8,14 @@ The seeding module provides infrastructure for reproducible benchmark runs. Seed
 
 The abstract base class that defines the seeding interface. Implement this to create custom seeding strategies.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.SeedGenerator
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.DefaultSeedGenerator
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/seeding.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/seeding.py){ .md-source-file }
 
 ::: maseval.core.seeding.SeedingError

--- a/docs/reference/simulator.md
+++ b/docs/reference/simulator.md
@@ -2,7 +2,7 @@
 
 Simulators in MASEval are used to create reproducible and scalable testing environments for multi-agent systems. Their primary function is to mock the behavior of external dependencies such as APIs, databases, or human users. By using simulators, developers can test agent interactions in a controlled, isolated environment. This approach eliminates variability from external factors like network latency or API availability, ensuring that benchmark results are consistent and deterministic. This allows for a more precise evaluation of agent performance and reliable comparison between different implementations.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/simulator.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/simulator.py){ .md-source-file }
 
 ::: maseval.core.simulator.LLMSimulator
 

--- a/docs/reference/simulator.md
+++ b/docs/reference/simulator.md
@@ -2,7 +2,7 @@
 
 Simulators in MASEval are used to create reproducible and scalable testing environments for multi-agent systems. Their primary function is to mock the behavior of external dependencies such as APIs, databases, or human users. By using simulators, developers can test agent interactions in a controlled, isolated environment. This approach eliminates variability from external factors like network latency or API availability, ensuring that benchmark results are consistent and deterministic. This allows for a more precise evaluation of agent performance and reliable comparison between different implementations.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/simulator.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/simulator.py){ .md-source-file }
 
 ::: maseval.core.simulator.LLMSimulator
 

--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -2,15 +2,15 @@
 
 Tasks define individual benchmark scenarios including inputs, expected outputs, and metadata for evaluation. Task queues control execution order and scheduling strategy.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L56){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L56){ .md-source-file }
 
 ::: maseval.core.task.Task
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L28){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L28){ .md-source-file }
 
 ::: maseval.core.task.TaskProtocol
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L19){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L19){ .md-source-file }
 
 ::: maseval.core.task.TimeoutAction
 
@@ -18,26 +18,26 @@ Tasks define individual benchmark scenarios including inputs, expected outputs, 
 
 Task queues determine the order in which tasks are executed. Pass a queue to `Benchmark.run(queue=...)` to customize scheduling.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L87){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L87){ .md-source-file }
 
 ::: maseval.core.task.BaseTaskQueue
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L257){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L257){ .md-source-file }
 
 ::: maseval.core.task.SequentialTaskQueue
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L277){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L277){ .md-source-file }
 
 ::: maseval.core.task.InformativeSubsetQueue
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L325){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L325){ .md-source-file }
 
 ::: maseval.core.task.DISCOQueue
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L413){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L413){ .md-source-file }
 
 ::: maseval.core.task.PriorityTaskQueue
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L459){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/task.py#L459){ .md-source-file }
 
 ::: maseval.core.task.AdaptiveTaskQueue

--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -2,15 +2,15 @@
 
 Tasks define individual benchmark scenarios including inputs, expected outputs, and metadata for evaluation. Task queues control execution order and scheduling strategy.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L56){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L56){ .md-source-file }
 
 ::: maseval.core.task.Task
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L28){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L28){ .md-source-file }
 
 ::: maseval.core.task.TaskProtocol
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L19){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L19){ .md-source-file }
 
 ::: maseval.core.task.TimeoutAction
 
@@ -18,26 +18,26 @@ Tasks define individual benchmark scenarios including inputs, expected outputs, 
 
 Task queues determine the order in which tasks are executed. Pass a queue to `Benchmark.run(queue=...)` to customize scheduling.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L87){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L87){ .md-source-file }
 
 ::: maseval.core.task.BaseTaskQueue
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L257){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L257){ .md-source-file }
 
 ::: maseval.core.task.SequentialTaskQueue
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L277){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L277){ .md-source-file }
 
 ::: maseval.core.task.InformativeSubsetQueue
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L325){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L325){ .md-source-file }
 
 ::: maseval.core.task.DISCOQueue
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L413){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L413){ .md-source-file }
 
 ::: maseval.core.task.PriorityTaskQueue
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/task.py#L459){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/task.py#L459){ .md-source-file }
 
 ::: maseval.core.task.AdaptiveTaskQueue

--- a/docs/reference/usage.md
+++ b/docs/reference/usage.md
@@ -4,7 +4,7 @@ Usage and cost tracking provides data classes for recording resource consumption
 
 See the [Usage & Cost Tracking guide](../guides/usage-tracking.md) for usage patterns and examples.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/usage.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/usage.py){ .md-source-file }
 
 ::: maseval.core.usage.Usage
 
@@ -18,6 +18,6 @@ See the [Usage & Cost Tracking guide](../guides/usage-tracking.md) for usage pat
 
 ::: maseval.core.usage.UsageReporter
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/interface/usage.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/usage.py){ .md-source-file }
 
 ::: maseval.interface.usage.LiteLLMCostCalculator

--- a/docs/reference/usage.md
+++ b/docs/reference/usage.md
@@ -4,7 +4,7 @@ Usage and cost tracking provides data classes for recording resource consumption
 
 See the [Usage & Cost Tracking guide](../guides/usage-tracking.md) for usage patterns and examples.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/usage.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/usage.py){ .md-source-file }
 
 ::: maseval.core.usage.Usage
 
@@ -18,6 +18,6 @@ See the [Usage & Cost Tracking guide](../guides/usage-tracking.md) for usage pat
 
 ::: maseval.core.usage.UsageReporter
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/interface/usage.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/interface/usage.py){ .md-source-file }
 
 ::: maseval.interface.usage.LiteLLMCostCalculator

--- a/docs/reference/user.md
+++ b/docs/reference/user.md
@@ -4,7 +4,7 @@ In many real-world applications, Multi-Agent Systems (MAS) are designed to inter
 
 The `LLMUser` is initialized with a persona and a scenario, both of which are typically defined within a Task. This tight integration allows for dynamic and context-aware simulations. For example, a Task might generate a random birthdate for the user. This birthdate is then passed to both the `LLMUser` and the `Evaluator`. The user will use this information in its conversation with the MAS, and the `Evaluator` will check if the MAS correctly processes and remembers this information. This mechanism enables the creation of sophisticated and reliable benchmarks that can assess the interactive capabilities of a MAS.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/user.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/user.py){ .md-source-file }
 
 ::: maseval.core.user.User
 

--- a/docs/reference/user.md
+++ b/docs/reference/user.md
@@ -4,7 +4,7 @@ In many real-world applications, Multi-Agent Systems (MAS) are designed to inter
 
 The `LLMUser` is initialized with a persona and a scenario, both of which are typically defined within a Task. This tight integration allows for dynamic and context-aware simulations. For example, a Task might generate a random birthdate for the user. This birthdate is then passed to both the `LLMUser` and the `Evaluator`. The user will use this information in its conversation with the MAS, and the `Evaluator` will check if the MAS correctly processes and remembers this information. This mechanism enables the creation of sophisticated and reliable benchmarks that can assess the interactive capabilities of a MAS.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/user.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/user.py){ .md-source-file }
 
 ::: maseval.core.user.User
 

--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -2,8 +2,8 @@
 
 In here, utilities are documented that are used across the library.
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/tracing.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/tracing.py){ .md-source-file }
 ::: maseval.core.tracing.TraceableMixin
 
-[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/config.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/MASEval/blob/main/maseval/core/config.py){ .md-source-file }
 ::: maseval.core.config.ConfigurableMixin

--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -2,8 +2,8 @@
 
 In here, utilities are documented that are used across the library.
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/tracing.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/tracing.py){ .md-source-file }
 ::: maseval.core.tracing.TraceableMixin
 
-[:material-github: View source](https://github.com/parameterlab/maseval/blob/main/maseval/core/config.py){ .md-source-file }
+[:material-github: View source](https://github.com/maseval/maseval/blob/main/maseval/core/config.py){ .md-source-file }
 ::: maseval.core.config.ConfigurableMixin

--- a/examples/five_a_day_benchmark/five_a_day_benchmark.ipynb
+++ b/examples/five_a_day_benchmark/five_a_day_benchmark.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 5 A Day Benchmark\n",
     "\n",
-    "[![Open Notebook on GitHub](https://img.shields.io/badge/Open%20Notebook%20on-GitHub-blue?logo=github)](https://github.com/parameterlab/MASEval/blob/main/examples/five_a_day_benchmark/five_a_day_benchmark.ipynb)\n",
+    "[![Open Notebook on GitHub](https://img.shields.io/badge/Open%20Notebook%20on-GitHub-blue?logo=github)](https://github.com/maseval/MASEval/blob/main/examples/five_a_day_benchmark/five_a_day_benchmark.ipynb)\n",
     "\n",
     "This notebook is available as a Jupyter notebook — clone the repo and run it yourself!\n",
     "\n",
@@ -956,11 +956,11 @@
     "\n",
     "## Resources\n",
     "\n",
-    "- [MASEval Documentation](https://github.com/parameterlab/MASEval)\n",
-    "- Example code: [`examples/five_a_day_benchmark/`](https://github.com/parameterlab/MASEval/tree/main/examples/five_a_day_benchmark)\n",
-    "- Example data: [`examples/five_a_day_benchmark/data/`](https://github.com/parameterlab/MASEval/tree/main/examples/five_a_day_benchmark/data)\n",
-    "- Tool implementations: [`examples/five_a_day_benchmark/tools/`](https://github.com/parameterlab/MASEval/tree/main/examples/five_a_day_benchmark/tools)\n",
-    "- Evaluator implementations: [`examples/five_a_day_benchmark/evaluators/`](https://github.com/parameterlab/MASEval/tree/main/examples/five_a_day_benchmark/evaluators)"
+    "- [MASEval Documentation](https://github.com/maseval/MASEval)\n",
+    "- Example code: [`examples/five_a_day_benchmark/`](https://github.com/maseval/MASEval/tree/main/examples/five_a_day_benchmark)\n",
+    "- Example data: [`examples/five_a_day_benchmark/data/`](https://github.com/maseval/MASEval/tree/main/examples/five_a_day_benchmark/data)\n",
+    "- Tool implementations: [`examples/five_a_day_benchmark/tools/`](https://github.com/maseval/MASEval/tree/main/examples/five_a_day_benchmark/tools)\n",
+    "- Evaluator implementations: [`examples/five_a_day_benchmark/evaluators/`](https://github.com/maseval/MASEval/tree/main/examples/five_a_day_benchmark/evaluators)"
    ]
   }
  ],

--- a/examples/introduction/tutorial.ipynb
+++ b/examples/introduction/tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Tiny Tutorial\n",
     "\n",
-    "[![Open Notebook on GitHub](https://img.shields.io/badge/Open%20Notebook%20on-GitHub-blue?logo=github)](https://github.com/parameterlab/MASEval/blob/main/examples/introduction/tutorial.ipynb)\n",
+    "[![Open Notebook on GitHub](https://img.shields.io/badge/Open%20Notebook%20on-GitHub-blue?logo=github)](https://github.com/maseval/MASEval/blob/main/examples/introduction/tutorial.ipynb)\n",
     "\n",
     "This notebook is available as a Jupyter notebook — clone the repo and run it yourself!\n",
     "\n",
@@ -721,7 +721,7 @@
     "3. Experiment with different agent frameworks (LangGraph, LlamaIndex)\n",
     "4. Add callbacks for logging and tracing\n",
     "\n",
-    "For more information, visit the [MASEval documentation](https://github.com/parameterlab/MASEval)."
+    "For more information, visit the [MASEval documentation](https://github.com/maseval/MASEval)."
    ]
   }
  ],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ docs_dir: docs
 site_dir: site
 site_author: ParameterLab
 site_url: https://maseval.readthedocs.io/en/stable/
-repo_name: parameterlab/maseval
-repo_url: https://github.com/parameterlab/maseval
+repo_name: maseval/maseval
+repo_url: https://github.com/maseval/maseval
 edit_uri: edit/main/docs/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ docs_dir: docs
 site_dir: site
 site_author: ParameterLab
 site_url: https://maseval.readthedocs.io/en/stable/
-repo_name: maseval/maseval
-repo_url: https://github.com/maseval/maseval
+repo_name: maseval/MASEval
+repo_url: https://github.com/maseval/MASEval
 edit_uri: edit/main/docs/
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,10 +140,10 @@ examples = [
 all = ["maseval[examples,transformers,wandb,multiagentbench]"]
 
 [project.urls]
-"Homepage" = "https://github.com/parameterlab/MASEval"
-"Bug Tracker" = "https://github.com/parameterlab/MASEval/issues"
+"Homepage" = "https://github.com/maseval/MASEval"
+"Bug Tracker" = "https://github.com/maseval/MASEval/issues"
 "Documentation" = "https://maseval.readthedocs.io/en/stable/"
-"Changelog" = "https://github.com/parameterlab/MASEval/blob/main/CHANGELOG.md"
+"Changelog" = "https://github.com/maseval/MASEval/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 # Development tools (linting, testing) - for contributors only


### PR DESCRIPTION
## Description

The repository moved from `parameterlab/MASEval` to `maseval/MASEval`. This sweeps every stale slug reference (`parameterlab/` → `maseval/`) across the repo so links, badges, docs "View source" links, notebooks, and packaging metadata point at the new location.

**Changed (43 files, 90 replacements):**
- `README.md` — logo image URLs, Tests badge, codecov badge
- `pyproject.toml` — Homepage / Bug Tracker / Changelog project URLs (these render on the PyPI page)
- `mkdocs.yml` — `repo_name` and `repo_url`
- `CHANGELOG.md` — version compare links
- `CONTRIBUTING.md`, `.github/RELEASE.md`
- ~35 `docs/` pages — `View source` and cross-reference links
- 2 notebooks — `examples/five_a_day_benchmark` and `examples/introduction`

**Intentionally preserved (company / legal, not the repo):**
- `parameterlab.de` domain (README org badge, author email)
- `NT ParameterLab GmbH` copyright in `LICENSE`
- `site_author: ParameterLab` in `mkdocs.yml`

No Python source changed; no functional/runtime impact. The pyproject URL fix takes effect on the next release (it won't retroactively update the already-tagged 0.5.0 PyPI page).

## Type of Change

- [x] Documentation update
- [x] Code quality improvement (refactoring, formatting, etc.)

## Checklist

- [x] Verified no stray `parameterlab/` slug remains; company/legal references preserved
- [x] Documentation-only change (no CHANGELOG entry needed)
