### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like that you are providing a standardized framework for evaluating multi-agent systems.

1. [LOW] LangChain tool has no description
   File: examples/converse_benchmark/converse_benchmark.py
   What it means: LangChain exposes a tool to the model through its description: for an @tool-decorated function or a StructuredTool, the description defaults to the wrapped function's docstring.

2. [LOW] LangChain tool has no description
   File: examples/converse_benchmark/converse_benchmark.py
   What it means: LangChain exposes a tool to the model through its description: for an @tool-decorated function or a StructuredTool, the description defaults to the wrapped function's docstring.

3. [LOW] LangChain tool has no description
   File: examples/five_a_day_benchmark/tools/base.py
   What it means: LangChain exposes a tool to the model through its description: for an @tool-decorated function or a StructuredTool, the description defaults to the wrapped function's docstring.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)